### PR TITLE
feat: enable flight date filtering

### DIFF
--- a/src/services/flightApi.ts
+++ b/src/services/flightApi.ts
@@ -66,7 +66,7 @@ export interface AviationStackFlight {
 export async function searchFlights(params: {
   dep_iata?: string;
   arr_iata?: string;
-  // SUPPRIME flight_date
+  flight_date?: string;
   // airline_name?: string; // optionnel, mais peu fiable avec la version gratuite
   flight_status?: string; // "active", "landed", "scheduled"
 }) {
@@ -81,6 +81,7 @@ export async function searchFlights(params: {
   };
   if (params.dep_iata) safeParams.dep_iata = params.dep_iata;
   if (params.arr_iata) safeParams.arr_iata = params.arr_iata;
+  if (params.flight_date) safeParams.flight_date = params.flight_date;
   if (params.flight_status) safeParams.flight_status = params.flight_status;
 
   const query = new URLSearchParams(safeParams);


### PR DESCRIPTION
## Summary
- allow filtering aviation stack flights by date by accepting and passing flight_date

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint .` (fails: Unexpected any, etc.)

------
https://chatgpt.com/codex/tasks/task_e_6892d21e4a9c8321be91c4c55063fb48