### PR TITLE
feat: add admin statistics page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import AdminUserTable from '@/components/AdminUserTable';
 import { Header } from '../../components/Header';
 export default function AdminUsersPage() {
@@ -6,6 +7,11 @@ export default function AdminUsersPage() {
     <div className="max-w-6xl mx-auto px-4 py-8">
       <Header />
       <h1 className="text-2xl font-bold mb-6">Espace Administrateur</h1>
+      <div className="mb-4">
+        <Link href="/admin/stats" className="text-blue-500 hover:underline">
+          Voir les statistiques
+        </Link>
+      </div>
       <AdminUserTable />
     </div>
   );

--- a/src/app/admin/stats/page.tsx
+++ b/src/app/admin/stats/page.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Header } from '@/components/Header';
+import AdminStats from '@/components/AdminStats';
+
+export default function AdminStatsPage() {
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <Header />
+      <h1 className="text-2xl font-bold mb-6">Espace Statistiques</h1>
+      <AdminStats />
+    </div>
+  );
+}

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { requireAdmin } from '@/lib/auth';
+
+const prisma = new PrismaClient();
+
+export async function GET(req: Request) {
+  try {
+    requireAdmin(req as any);
+    const usersCount = await prisma.user.count();
+    const reservedCount = await prisma.reservation.count({ where: { status: 'active' } });
+    const cancelledCount = await prisma.reservation.count({ where: { status: 'cancelled' } });
+    const paidCount = await prisma.reservation.count({ where: { paid: true } });
+    return NextResponse.json({ usersCount, reservedCount, cancelledCount, paidCount });
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 403 });
+  }
+}

--- a/src/components/AdminStats.tsx
+++ b/src/components/AdminStats.tsx
@@ -1,0 +1,39 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+
+type Stats = {
+  usersCount: number;
+  reservedCount: number;
+  cancelledCount: number;
+  paidCount: number;
+};
+
+export default function AdminStats() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      const res = await fetch('/api/admin/stats', { credentials: 'include' });
+      const data = await res.json();
+      if (res.ok) setStats(data);
+      else setError(data.error);
+    };
+    fetchStats();
+  }, []);
+
+  if (error) return <p className="text-red-500">{error}</p>;
+  if (!stats) return <p>Chargement...</p>;
+
+  return (
+    <div className="bg-white rounded shadow p-6 mb-6">
+      <h2 className="text-xl font-semibold mb-4">Statistiques</h2>
+      <ul className="space-y-2">
+        <li>Utilisateurs : {stats.usersCount}</li>
+        <li>Vols réservés : {stats.reservedCount}</li>
+        <li>Vols annulés : {stats.cancelledCount}</li>
+        <li>Vols payés : {stats.paidCount}</li>
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin stats API to fetch counts for users and reservations
- build admin-only stats page and component
- link stats page from admin dashboard

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompts configuration)

------
https://chatgpt.com/codex/tasks/task_e_6895094c8734832187c6e48a718ab470